### PR TITLE
Keep all GDELT columns; restructure article dict

### DIFF
--- a/coronavirus_map/application/data_generation_service.py
+++ b/coronavirus_map/application/data_generation_service.py
@@ -43,5 +43,5 @@ class DataGenerationService:
         else:
             news = retriever.scrape_latest_gdelt_datasets(4*24*days)
         for article in news:
-            file_path = os.path.join(output_directory, f"{article['GlobalEventID']}.json")
+            file_path = os.path.join(output_directory, f"{article['GDELT']['GlobalEventID']}.json")
             write_output_file(file_path, article)

--- a/coronavirus_map/domain/news_retrieval_service.py
+++ b/coronavirus_map/domain/news_retrieval_service.py
@@ -28,6 +28,9 @@ from coronavirus_map.domain.news_retrieval_service_globals import *
 class NewsRetrievalService:
     """
     Service to retrieve news articles and write to JSON files, with added support for GDELT TSVs.
+    Args:
+        sample_size: float (0, 1), fraction of articles to scrape
+        blacklisted_domains: list, URL's not to scrape using newspaper
     Methods:
         scrape_latest_gdelt_dataset: generates articles from last 15 minutes
         scrape_latest_gdelt_datasets: generates articles from last N*15 minutes

--- a/coronavirus_map/domain/news_retrieval_service.py
+++ b/coronavirus_map/domain/news_retrieval_service.py
@@ -1,11 +1,10 @@
 """
 Service to retrieve news articles from GDELT news tracker.
 Usage:
-    import src.domain.news_retrieval_service as news_retrieval_service
+    import coronavirus_map.domain.news_retrieval_service as news_retrieval_service
     retriever = news_retrieval_service.NewsRetrievalService(
         sample_size,
         blacklisted_domains,
-        gdelt_columns_to_keep
     )
     # to generate articles from the last 15 minutes
     retriever.scrape_latest_gdelt_dataset()

--- a/coronavirus_map/domain/news_retrieval_service_globals.py
+++ b/coronavirus_map/domain/news_retrieval_service_globals.py
@@ -10,12 +10,6 @@ GDELT_LATEST_UPDATE_URL = "http://data.gdeltproject.org/gdeltv2/lastupdate.txt"
 
 GDELT_MASTER_LIST_URL = "http://data.gdeltproject.org/gdeltv2/masterfilelist.txt"
 
-NECESSARY_GDELT_COLUMNS = [
-    "GlobalEventID",
-    "DATEADDED",
-    "SOURCEURL",
-]
-
 GDELT_COLUMNS = [
     "GlobalEventID",
     "Day",


### PR DESCRIPTION
Summary:
Previously, we dropped GDELT columns we didn't think were relevant.
However, we soon decided we do want to keep location data, and there's
no reason to proactively throw out other information. This PR keeps all
GDELT data and restructures article dictionaries to better reflect this.

Test plan:
Ran data generation script. It works.