### PR TITLE
Rename news_filtering_service to news_classification_service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ To generate a CSV of GDELT GlobalEventIDs to include in a geographically balance
 ```
 select_balanced_dataset --data_directory=DATA_DIRECTORY --output_file=OUTPUT_FILE
 ```
+## Map Generation
 
-## To-Do List
-1. Convert repository from package to application
+You can generate a map with the latest coronavirus news:
+```
+populate_map
+```
+Alternatively, you can generate a map from data/news_articles:
+```
+backfill_map
+```

--- a/coronavirus_map/application/map_population_service.py
+++ b/coronavirus_map/application/map_population_service.py
@@ -2,7 +2,7 @@
 
 import training_scripts.domain.dataframe_sampling_service as dataframe_sampling_service
 import training_scripts.domain.news_retrieval_service as news_retrieval_service
-import coronavirus_map.domain.news_filtering_service as news_filtering_service
+import coronavirus_map.domain.news_classification_service as news_classification_service
 import coronavirus_map.domain.map_generation_service as map_generation_service
 
 class MapPopulationService:
@@ -10,7 +10,7 @@ class MapPopulationService:
     Class that populates a map with last 15 minutes of GDELT data.
     Args:
         retriever: news_retrieval_service.NewsRetrievalService
-        filterer: news_filtering_service.NewsFilteringService
+         classifier: news_classification_service.NewsClassificationService
         mapper: map_generation_service.MapGenerationService
     Methods:
         populate_map: populates map
@@ -18,15 +18,15 @@ class MapPopulationService:
 
     def __init__(self,
                  retriever: news_retrieval_service.NewsRetrievalService,
-                 filterer: news_filtering_service.NewsFilteringService,
+                 classifier: news_classification_service.NewsClassificationService,
                  mapper: map_generation_service.MapGenerationService):
         self.retriever = retriever
-        self.filterer = filterer
+        self.classifier = classifier
         self.mapper = mapper
 
     def populate_map(self):
         """Function to populate map with last 15 minutes of GDELT data."""
         news = self.retriever.scrape_latest_gdelt_dataset()
-        covid_news = self.filterer.find_coronavirus_stories(news)
+        covid_news = self.classifier.find_coronavirus_stories(news)
         plotly_map = self.mapper.generate_map(covid_news)
         return plotly_map

--- a/coronavirus_map/cli.py
+++ b/coronavirus_map/cli.py
@@ -6,7 +6,7 @@ import json
 import click
 
 import coronavirus_map.application.map_population_service as map_population_service
-import coronavirus_map.domain.news_filtering_service as news_filtering_service
+import coronavirus_map.domain.news_classification_service as news_classification_service
 import coronavirus_map.domain.map_generation_service as map_generation_service
 import training_scripts.application.data_generation_service as data_generation_service
 import training_scripts.application.dataset_selection_service as dataset_selection_service
@@ -23,9 +23,9 @@ def populate_map(output_file):
     """
     sampler = dataframe_sampling_service.DataFrameSamplingService()
     retriever = news_retrieval_service.NewsRetrievalService(sampler, 1, False)
-    filterer = news_filtering_service.NewsFilteringService()
+    classifier = news_classification_service.NewsClassificationService()
     mapper = map_generation_service.MapGenerationService()
-    populator = map_population_service.MapPopulationService(retriever, filterer, mapper)
+    populator = map_population_service.MapPopulationService(retriever, classifier, mapper)
     plotly_map = populator.populate_map()
     plotly_map.write_html(output_file)
 
@@ -41,8 +41,8 @@ def backfill_map(output_file):
     def json_load(file_path):
         with open(file_path, 'r') as file:
             return json.load(file)
-    filterer = news_filtering_service.NewsFilteringService()
-    news_articles = filterer.find_coronavirus_stories(
+    classifier = news_classification_service.NewsClassificationService()
+    news_articles = classifier.find_coronavirus_stories(
         json_load(path) for path in glob.glob('data/news_articles/balanced_dataset/*')
     )
     mapper = map_generation_service.MapGenerationService()

--- a/coronavirus_map/domain/news_classification_service.py
+++ b/coronavirus_map/domain/news_classification_service.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-self-use
 # pylint: disable=too-few-public-methods
 
-class NewsFilteringService:
+class NewsClassificationService:
     """
     Class to locate news articles related to the novel coronavirus.
     Methods:


### PR DESCRIPTION
Summary:
Previously, we used language of "filtering" and "filterer" throughout the repository. This was clumsy, and it didn't reflect our intention to classify data. This PR renames "filter" to "classifier". Additionally, it updates the README.

Test plan:
We still do not have unit tests, but I ran all existing command line utilities without failure.